### PR TITLE
Add Lidl receipt analysis docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 ## Featured Projects
 | Project | 📓 Notebook | What it shows |
 |---------|-------------|---------------|
-| Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> | Parses Lidl receipts and summarizes monthly spend |
+| Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> · [Docs](docs/lidl_receipt_analysis.md) | Parses Lidl receipts and summarizes monthly spend |
 | Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> | Forecasts warehouse stock levels with the Prophet library |
 | PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> | Converts PDF catalogue tables to Excel using OCR |
 | Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
@@ -29,7 +29,7 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 ## Näyteprojekteja
 | Projekti | 📓 Notebook | Kuvaus |
 |----------|-------------|--------|
-| Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> | Analysoi kuittidataa ja tuottaa kuukausikoosteet |
+| Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> · [Docs](docs/lidl_receipt_analysis.md) | Analysoi kuittidataa ja tuottaa kuukausikoosteet |
 | Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> | Ennustaa varastotarpeet Prophet‑kirjastolla |
 | PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
 | Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |

--- a/docs/lidl_receipt_analysis.md
+++ b/docs/lidl_receipt_analysis.md
@@ -1,0 +1,39 @@
+# Lidl Receipt Analysis
+
+## Objective
+This notebook converts scanned Lidl grocery receipts into structured spend summaries. It performs OCR on each image, categorizes items, and produces monthly totals and visualizations.
+
+## Input Format
+- Folder containing receipt images (`.png`, `.jpg`, `.jpeg`). Filenames should begin with `YYYY.MM.DD` so the date can be inferred.
+- Parsed data are saved to a CSV with columns such as `item`, `price`, `purchase_count`, `item_qty`, `weight_kg`, `date`, and `category`.
+
+## Main Functions
+- `categorize(name: str) -> str`: maps product names to categories like Dairy, Meat, Bakery, Drinks, Snacks, or Other.
+- `extract_receipt_data(path: str) -> list[dict]`: runs Tesseract OCR on a receipt image, merges continuation lines, captures quantities or weights, and returns item dictionaries.
+- `process_receipts_folder(folder: str, csv_out: str) -> pd.DataFrame`: processes all receipt images in a folder, applies `extract_receipt_data`, saves results to CSV, and tags each item with a category.
+
+## Example Output
+Running the notebook on sample receipts generates a monthly spend table and category breakdown:
+
+```
+Monthly spend
+     month  Total Spend
+0  2025-05       802.57
+
+Top-5 spend items / month
+      month                      item  price
+25  2025-05   Ehrmann Maitorahka 0,2%  30.26
+20  2025-05  Bellarom Crema kahvipavu  23.50
+...
+
+2025-05 – spend by category
+  category   price
+0    Dairy   77.80
+1     Meat   31.61
+...
+Heaviest 5 items (kg total)
+item
+Varhaiskaali                4.622
+Kurkku Suomi                3.918
+...
+```


### PR DESCRIPTION
## Summary
- document Lidl receipt financial tracker notebook
- link documentation from README

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a2977ebfe88323b9734ed2ef1ffd50