### PR TITLE
Add warehouse stock estimator documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 | Project | 📓 Notebook | What it shows |
 |---------|-------------|---------------|
 | Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> · [Docs](docs/lidl_receipt_analysis.md) | Parses Lidl receipts and summarizes monthly spend |
-| Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> | Forecasts warehouse stock levels with the Prophet library |
+| Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> · [Docs](docs/warehouse_stock_estimator.md) | Forecasts warehouse stock levels with the Prophet library |
 | PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> | Converts PDF catalogue tables to Excel using OCR |
 | Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
 | General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
@@ -30,7 +30,7 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 | Projekti | 📓 Notebook | Kuvaus |
 |----------|-------------|--------|
 | Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> · [Docs](docs/lidl_receipt_analysis.md) | Analysoi kuittidataa ja tuottaa kuukausikoosteet |
-| Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> | Ennustaa varastotarpeet Prophet‑kirjastolla |
+| Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> · [Docs](docs/warehouse_stock_estimator.md) | Ennustaa varastotarpeet Prophet‑kirjastolla |
 | PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
 | Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |
 | Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|

--- a/docs/warehouse_stock_estimator.md
+++ b/docs/warehouse_stock_estimator.md
@@ -1,0 +1,26 @@
+# Warehouse Stock Estimator
+
+## Installation
+Create a Python environment and install the required libraries:
+
+```bash
+pip install pandas numpy prophet plotly openpyxl kaleido
+```
+
+## Data Preparation
+1. Mount Google Drive (if using Colab) or set a local data directory.
+2. Generate or load historical daily demand for each item. Data should contain:
+   - `item_id`: unique identifier
+   - `ds`: date column
+   - `daily_sales`: units sold per day
+3. Use the helper function to simulate stock levels from demand and export the results to Excel for verification.
+
+## Running Forecasts
+1. Train a Prophet model on the historical `daily_sales` data.
+2. Create a future dataframe and forecast the next 180 days of demand.
+3. Accumulate predicted sales to project remaining inventory for each item.
+4. Save a dashboard (`forecast_dashboard.xlsx`) and individual item plots to the data directory.
+
+## Interpreting Plots
+The notebook plots projected inventory levels with a horizontal reorder threshold.  
+When the inventory line crosses this threshold, schedule replenishment before the indicated date.


### PR DESCRIPTION
## Summary
- Document Prophet-based warehouse stock estimator workflow
- Link new documentation from the project table

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a299b6c190832391b1c67827640bb1