### PR TITLE
docs: add pdf to excel converter guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 |---------|-------------|---------------|
 | Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> · [Docs](docs/lidl_receipt_analysis.md) | Parses Lidl receipts and summarizes monthly spend |
 | Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> | Forecasts warehouse stock levels with the Prophet library |
-| PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> | Converts PDF catalogue tables to Excel using OCR |
+| PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> · [Docs](docs/pdf_to_excel_converter.md) | Converts PDF catalogue tables to Excel using OCR |
 | Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
 | General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
 
@@ -31,7 +31,7 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 |----------|-------------|--------|
 | Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> · [Docs](docs/lidl_receipt_analysis.md) | Analysoi kuittidataa ja tuottaa kuukausikoosteet |
 | Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> | Ennustaa varastotarpeet Prophet‑kirjastolla |
-| PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
+| PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> · [Docs](docs/pdf_to_excel_converter.md) | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
 | Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |
 | Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|
 

--- a/docs/pdf_to_excel_converter.md
+++ b/docs/pdf_to_excel_converter.md
@@ -1,0 +1,44 @@
+# PDF to Excel Converter
+
+## Objective
+Convert tabular pages from a PDF catalogue into a structured Excel file using OCR.
+
+## Command-line execution
+1. Install dependencies and the Tesseract OCR engine:
+   ```bash
+   pip install pymupdf pytesseract pillow pandas openpyxl pdfplumber
+   sudo apt-get install -y tesseract-ocr
+   ```
+2. Run the notebook headlessly to produce `output.xlsx`:
+   ```bash
+   jupyter nbconvert --to notebook --execute Toolbox/notebooks/pdf_to_excel_converter.ipynb \
+     --ExecutePreprocessor.timeout=600 --output executed.ipynb
+   ```
+   Adjust the variables at the top of the second cell before running:
+   - `PDF_PATH`: path to the source PDF
+   - `PAGE_NUM`: 1-based page index
+   - `DPI`: rasterization resolution (e.g. `300`)
+   - `OCR_LANG`: Tesseract language code (e.g. `eng`)
+   - `CROP_BOX`: bounding box `(x0, y0, x1, y1)` for the table region
+   - `OUT_XLSX`: location for the Excel file
+
+## Sample input
+Example settings used in the notebook:
+```python
+PDF_PATH = "/content/onepage.pdf"
+PAGE_NUM = 1
+DPI = 300
+OCR_LANG = "eng"
+CROP_BOX = (70.75448724699189, 109.77600105, 545.3519891000003, 215.16000375)
+OUT_XLSX = "/content/output.xlsx"
+```
+
+## Excel output
+The converter writes a workbook with a single sheet named `Jockey Wheels` containing:
+
+- `Part nr.`
+- `Description`
+- `Max static load`
+- `Max dynamic load`
+
+Each row represents one entry from the catalogue table.


### PR DESCRIPTION
## Summary
- document PDF-to-Excel converter workflow and CLI execution
- cross-link new guide from project README tables

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas matplotlib` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pip install -e Toolbox` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a299c3175c8323b6f6b953a5c464d6