### PR TITLE
Add product keyword extractor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 | Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> · [Docs](docs/lidl_receipt_analysis.md) | Parses Lidl receipts and summarizes monthly spend |
 | Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> | Forecasts warehouse stock levels with the Prophet library |
 | PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> | Converts PDF catalogue tables to Excel using OCR |
-| Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
+| Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> · [Docs](docs/product_keyword_extractor.md) | Extracts technical keywords from messy product descriptions for MDM preprocessing |
 | General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
 
 
@@ -32,6 +32,6 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 | Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> · [Docs](docs/lidl_receipt_analysis.md) | Analysoi kuittidataa ja tuottaa kuukausikoosteet |
 | Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> | Ennustaa varastotarpeet Prophet‑kirjastolla |
 | PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
-| Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |
+| Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> · [Docs](docs/product_keyword_extractor.md) | Poimii tekniset avainsanat sekavasta tuotedatasta |
 | Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|
 

--- a/docs/product_keyword_extractor.md
+++ b/docs/product_keyword_extractor.md
@@ -1,0 +1,58 @@
+# Product Keyword Extractor
+
+## Objective
+Extract technical keywords from product descriptions to standardize data for Master Data Management or catalog cleanup.
+
+## Input Format
+- Excel file with columns `ItemID`, `ItemDescrEng1`, `ItemDescrEng2`
+
+## Steps
+1. **Load data** using pandas `read_excel` and combine the two description columns:
+   ```python
+   df = pd.read_excel(file_path)
+   df["FullDescription"] = df["ItemDescrEng1"] + " " + df["ItemDescrEng2"].fillna("")
+   ```
+2. **Define keyword categories** as a dictionary where each category maps to a list of possible terms:
+   ```python
+   categories = {
+       "Din": ["931", "934", "933"],
+       "material": ["BRASS", "MS", "POLYAMIDE"],
+       "kovuus": ["10.9", "8.8", "12.9"],
+       "m": ["M5", "M6", "M8", "M10", "M12"],
+       "Words": ["DACRO", "ZINCPL", "PLAIN", "DACLIT"],
+   }
+   ```
+3. **Create a processing function** that searches each description for category terms and returns the first match per category:
+   ```python
+   import re
+
+   def process_description(description: str) -> dict:
+       keywords = {}
+       if not isinstance(description, str):
+           return keywords
+       for category, terms in categories.items():
+           for term in terms:
+               if re.search(rf"\b{re.escape(term)}\b", description, re.IGNORECASE):
+                   keywords[category] = term
+                   break
+       return keywords
+   ```
+4. **Apply keyword extraction** across all product descriptions:
+   ```python
+   df["Keywords"] = df["FullDescription"].apply(process_description)
+   ```
+5. **Optional – export results** to Excel for further use:
+   ```python
+   df.to_excel("cleaned_product_data.xlsx", index=False)
+   ```
+
+## Example Output
+Parsing a description like `DIN 931 10.9 M6 x 50 ZINCPL` produces:
+```python
+{
+    'Din': '931',
+    'kovuus': '10.9',
+    'm': 'M6',
+    'Words': 'ZINCPL'
+}
+```


### PR DESCRIPTION
## Summary
- Document product keyword extraction workflow with step-by-step code snippets and example output
- Reference the new documentation from the README in both English and Finnish project tables

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas matplotlib seaborn pillow pytesseract` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a299c47fbc832391b08097927c784d