### PR TITLE
Document GPT4All product demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 | Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> | Forecasts warehouse stock levels with the Prophet library |
 | PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> | Converts PDF catalogue tables to Excel using OCR |
 | Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
-| General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
+| General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> · [Docs](docs/gpt4all_product_demo.md) | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
 
 
 
@@ -33,5 +33,5 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 | Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> | Ennustaa varastotarpeet Prophet‑kirjastolla |
 | PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
 | Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |
-| Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|
+| Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> · [Docs](docs/gpt4all_product_demo.md) | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|
 

--- a/docs/gpt4all_product_demo.md
+++ b/docs/gpt4all_product_demo.md
@@ -1,0 +1,29 @@
+# GPT4All Product Demo
+
+## Setup
+- Install dependencies in the notebook:
+  ```bash
+  pip install gpt4all pydantic pandas numpy openpyxl rapidfuzz pdfplumber pillow pytesseract pdf2image requests
+  apt-get install poppler-utils tesseract-ocr
+  ```
+- The demo works without API keys or HF tokens. The notebook automatically downloads the small GPT4All model `orca-mini-3b-gguf2-q4_0.gguf` on first run.
+- Default configuration also fetches the IKEA BESTÅ PDF for testing.
+
+## Execution
+1. Adjust configuration variables such as `USE_DEFAULT_PDF`, `PAGE_INDEX`, and `GPT4ALL_MODEL`.
+2. Download the default PDF or upload your own, then extract text from the selected page with an OCR fallback.
+3. Parse the lines into `sku` and `description` columns. The notebook introduces random typos or size tweaks to simulate changes.
+4. For each original/current pair, the local model is prompted with:
+   ```
+   System: Compare two product lines. Output ONLY valid JSON: {"is_changed":bool,"differences":list of short strings,"confidence":0-1,"notes":optional}.
+   User: Original: {orig}
+   Current: {curr}
+   Rules: JSON only. If unsure, set is_changed=false with low confidence.
+   ```
+5. The responses are parsed into a `DiffReport` structure and merged with the dataset.
+6. Results are saved as CSV and XLSX files named `zero_setup_ikea_diff_<timestamp>.{csv,xlsx}`.
+
+## Expected Output
+- A table with columns like `sku`, `description`, `is_changed`, `differences`, `confidence`, and `notes`.
+- Exported CSV and Excel files in the Colab `/content` directory.
+- The demo is intended for experimentation; JSON accuracy improves with larger GPT4All models.


### PR DESCRIPTION
## Summary
- Add `docs/gpt4all_product_demo.md` with setup, execution and expected output for the SKU demo notebook.
- Link the new guide from both English and Finnish project tables in the README.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a299c5a2f48323aa758f8fc795c1b9