### PR TITLE
Add PDF to Excel converter script and test

### DIFF
--- a/Toolbox/scripts/pdf_to_excel_converter.py
+++ b/Toolbox/scripts/pdf_to_excel_converter.py
@@ -1,0 +1,93 @@
+"""Convert a PDF table into an Excel spreadsheet using OCR."""
+
+import io
+import re
+import fitz
+import pytesseract
+import pandas as pd
+from PIL import Image
+
+
+def extract_table(pdf_path: str, page_num: int = 1, crop_box: tuple | None = None, dpi: int = 300, lang: str = "eng") -> pd.DataFrame:
+    """Extract table rows from a PDF page using OCR.
+
+    Parameters
+    ----------
+    pdf_path: str
+        Path to the input PDF file.
+    page_num: int
+        1-based page number to process.
+    crop_box: tuple | None
+        Optional bounding box (x0, y0, x1, y1) to crop before OCR.
+    dpi: int
+        Rasterization resolution.
+    lang: str
+        Language for Tesseract OCR.
+    """
+    page = fitz.open(pdf_path).load_page(page_num - 1)
+    rect = fitz.Rect(*crop_box) if crop_box else page.rect
+    pix = page.get_pixmap(matrix=fitz.Matrix(dpi / 72, dpi / 72), clip=rect)
+    img = Image.open(io.BytesIO(pix.tobytes()))
+    ocr = pytesseract.image_to_string(img, lang=lang)
+    ocr_lines = [ln for ln in ocr.splitlines() if ln.strip()]
+    ocr_lines = [ln for ln in ocr_lines if not re.search(r"\bPart\s+nr", ln, re.I)]
+    clean_ocr = "\n".join(ocr_lines)
+    row_re = re.compile(
+        r"""^(?P<raw>[-FT]?P[A-Z0-9]{3,})\s+
+            (?P<desc>.*?)\s+
+            \|?\s*(?P<stat>\d+\s*kg)\s+
+            (?P<dyn>\d+\s*kg)\s*$""",
+        re.I | re.X | re.M,
+    )
+    ocr_map = str.maketrans({
+        "O": "0",
+        "o": "0",
+        "S": "5",
+        "s": "5",
+        "I": "1",
+        "l": "1",
+        "B": "8",
+        "-": "T",
+        "F": "T",
+        "f": "T",
+    })
+    rows: list[dict[str, str]] = []
+    for m in row_re.finditer(clean_ocr):
+        part_norm = m.group("raw").translate(ocr_map)
+        if re.fullmatch(r"TP\d{3,}", part_norm):
+            rows.append(
+                {
+                    "Part nr.": part_norm,
+                    "Description": m.group("desc").strip(),
+                    "Max static load": m.group("stat"),
+                    "Max dynamic load": m.group("dyn"),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def export_to_excel(df: pd.DataFrame, out_path: str, sheet_name: str = "Jockey Wheels") -> None:
+    """Save a DataFrame to an Excel file."""
+    with pd.ExcelWriter(out_path, engine="openpyxl") as xl:
+        df.to_excel(xl, sheet_name=sheet_name, index=False)
+
+
+def main() -> None:
+    """CLI entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Convert a PDF table to an Excel spreadsheet using OCR."
+    )
+    parser.add_argument("input_pdf", help="Path to the input PDF file")
+    parser.add_argument("output_xlsx", help="Path to the output XLSX file")
+    parser.add_argument("--page", type=int, default=1, help="1-based page number")
+    parser.add_argument("--lang", default="eng", help="Tesseract language code")
+    args = parser.parse_args()
+
+    df = extract_table(args.input_pdf, page_num=args.page, lang=args.lang)
+    export_to_excel(df, args.output_xlsx)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/Toolbox/tests/data/dummy_table.pdf
+++ b/Toolbox/tests/data/dummy_table.pdf
@@ -1,0 +1,31 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 123 >>
+stream
+BT /F1 12 Tf 50 750 Td (Part nr. Description Max static load Max dynamic load) Tj 0 -20 Td (TP123 Sample 10 kg 20 kg) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000415 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+485
+%EOF

--- a/Toolbox/tests/test_pdf_to_excel_converter.py
+++ b/Toolbox/tests/test_pdf_to_excel_converter.py
@@ -1,0 +1,19 @@
+import subprocess
+from pathlib import Path
+import pandas as pd
+
+
+def test_pdf_to_excel(tmp_path):
+    script = Path(__file__).resolve().parent.parent / "scripts" / "pdf_to_excel_converter.py"
+    input_pdf = Path(__file__).parent / "data" / "dummy_table.pdf"
+    output_xlsx = tmp_path / "out.xlsx"
+
+    subprocess.run(["python", str(script), str(input_pdf), str(output_xlsx)], check=True)
+
+    df = pd.read_excel(output_xlsx)
+    assert df.shape[0] == 1
+    row = df.iloc[0]
+    assert row["Part nr."] == "TP123"
+    assert row["Description"].startswith("Sample") or row["Description"] == "Sample"
+    assert row["Max static load"] == "10 kg"
+    assert row["Max dynamic load"] == "20 kg"


### PR DESCRIPTION
## Summary
- Convert notebook logic into `scripts/pdf_to_excel_converter.py` with OCR-based table extraction and Excel export functions
- Provide CLI to run `python pdf_to_excel_converter.py <input.pdf> <output.xlsx>`
- Add test with dummy PDF verifying conversion end-to-end

## Testing
- `pytest Toolbox/tests/test_pdf_to_excel_converter.py -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a299c705c08323b21af3711ac0abc9