### PR TITLE
feat: extract warehouse stock estimator to module + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 | Project | 📓 Notebook | What it shows |
 |---------|-------------|---------------|
 | Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> · [Docs](docs/lidl_receipt_analysis.md) | Parses Lidl receipts and summarizes monthly spend · module `lidltracker` |
-| Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> · [Docs](docs/warehouse_stock_estimator.md) | Forecasts warehouse stock levels with the Prophet library |
+| Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> · [Docs](docs/warehouse_stock_estimator.md) | Forecasts warehouse stock levels with the Prophet library · module `stockforecast` |
 | PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> | Converts PDF catalogue tables to Excel using OCR |
 | Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
 | General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> · [Docs](docs/gpt4all_product_demo.md) | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
@@ -30,7 +30,7 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 | Projekti | 📓 Notebook | Kuvaus |
 |----------|-------------|--------|
 | Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> · [Docs](docs/lidl_receipt_analysis.md) | Analysoi kuittidataa ja tuottaa kuukausikoosteet · moduuli `lidltracker` |
-| Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> · [Docs](docs/warehouse_stock_estimator.md) | Ennustaa varastotarpeet Prophet‑kirjastolla |
+| Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> · [Docs](docs/warehouse_stock_estimator.md) | Ennustaa varastotarpeet Prophet‑kirjastolla · moduuli `stockforecast` |
 | PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
 | Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |
 | Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> · [Docs](docs/gpt4all_product_demo.md) | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|

--- a/docs/warehouse_stock_estimator.md
+++ b/docs/warehouse_stock_estimator.md
@@ -1,5 +1,7 @@
 # Warehouse Stock Estimator
 
+Core functionality from the notebook is available as module `stockforecast`.
+
 ## Installation
 Create a Python environment and install the required libraries:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+# Runtime
+pandas>=1.5
+numpy>=1.24
+matplotlib>=3.7
+python-dateutil>=2.8
+click>=8.1
+prophet>=1.1
+
+# Optional OCR
+pytesseract>=0.3.10
+Pillow>=9.0
+opencv-python-headless>=4.8
+
+# Development
+pytest>=7.4
+black>=23.7
+ruff>=0.1

--- a/src/stockforecast/__init__.py
+++ b/src/stockforecast/__init__.py
@@ -1,0 +1,15 @@
+"""Utilities for forecasting warehouse stock levels."""
+
+from .forecast import (
+    generate_daily_demand,
+    simulate_stock_from_demand,
+    forecast_inventory,
+    main,
+)
+
+__all__ = [
+    "generate_daily_demand",
+    "simulate_stock_from_demand",
+    "forecast_inventory",
+    "main",
+]

--- a/src/stockforecast/forecast.py
+++ b/src/stockforecast/forecast.py
@@ -1,0 +1,163 @@
+"""Forecast inventory depletion using simple demand simulation and Prophet."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional, Type
+
+import click
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd  # type: ignore
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover
+    pd = None  # type: ignore
+    np = None  # type: ignore
+
+
+@dataclass
+class ForecastResult:
+    """Container for forecast output."""
+
+    forecast: "pd.DataFrame"
+    reorder_date: Optional[date]
+
+
+def generate_daily_demand(
+    start_date: str | date,
+    end_date: str | date,
+    base_sales_mean: int,
+    item_id: str,
+) -> "pd.DataFrame":
+    """Generate simulated daily demand for an item.
+
+    Args:
+        start_date: Beginning of the simulation period.
+        end_date: End of the simulation period.
+        base_sales_mean: Average daily sales used as the distribution mean.
+        item_id: Identifier for the item.
+
+    Returns:
+        DataFrame with columns ``item_id``, ``ds`` (date) and ``daily_sales``.
+    """
+    if pd is None or np is None:  # pragma: no cover - dependency missing
+        raise ImportError("pandas and numpy are required for demand generation")
+
+    dates = pd.date_range(start=start_date, end=end_date, freq="D")
+    df = pd.DataFrame({"ds": dates})
+    noise = np.random.normal(0, base_sales_mean * 0.1, len(df))
+    df["daily_sales"] = base_sales_mean + noise
+    df["daily_sales"] = df["daily_sales"].apply(lambda x: max(1, round(x)))
+    df["item_id"] = item_id
+    return df[["item_id", "ds", "daily_sales"]]
+
+
+def simulate_stock_from_demand(
+    df_demand_history: "pd.DataFrame",
+    initial_stock_multiplier: int,
+    replenishment_order_size_weeks: int,
+    lead_time_days: int,
+    safety_stock_days: int,
+) -> "pd.DataFrame":
+    """Simulate stock levels given historical demand.
+
+    Args:
+        df_demand_history: DataFrame with columns ``ds`` and ``daily_sales``.
+        initial_stock_multiplier: Multiplier for average daily sales to set initial stock.
+        replenishment_order_size_weeks: Size of replenishment orders measured in weeks of demand.
+        lead_time_days: Supplier lead time in days.
+        safety_stock_days: Additional days of stock to keep as safety.
+
+    Returns:
+        Copy of input ``df_demand_history`` with an added ``stock`` column.
+
+    Raises:
+        ValueError: If ``daily_sales`` column is missing.
+    """
+    if pd is None:  # pragma: no cover
+        raise ImportError("pandas is required for stock simulation")
+    if "daily_sales" not in df_demand_history.columns:
+        raise ValueError("df_demand_history must contain 'daily_sales' column")
+
+    df = df_demand_history.sort_values("ds").copy()
+    avg_daily_sales = df["daily_sales"].mean()
+    initial_stock = int(avg_daily_sales * initial_stock_multiplier)
+    current_stock = initial_stock
+    threshold = int(avg_daily_sales * (lead_time_days + safety_stock_days))
+    replenishment = int(avg_daily_sales * (replenishment_order_size_weeks * 7))
+    df["stock"] = 0
+    for i, row in df.iterrows():
+        df.loc[i, "stock"] = current_stock
+        current_stock -= row["daily_sales"]
+        if current_stock < threshold and i < len(df) - lead_time_days:
+            current_stock += replenishment
+    return df
+
+
+def forecast_inventory(
+    df_demand_history: "pd.DataFrame",
+    current_inventory: int,
+    forecast_days: int,
+    reorder_threshold: int,
+    prophet_cls: Optional[Type] = None,
+) -> ForecastResult:
+    """Forecast inventory depletion using Prophet.
+
+    Args:
+        df_demand_history: Historical demand with columns ``ds`` and ``daily_sales``.
+        current_inventory: Current stock level.
+        forecast_days: Number of days to forecast into the future.
+        reorder_threshold: Inventory level triggering replenishment.
+        prophet_cls: Optional ``prophet.Prophet`` class for dependency injection in tests.
+
+    Returns:
+        :class:`ForecastResult` with forecast dataframe and the date when inventory
+        falls below ``reorder_threshold`` (or ``None`` if not within range).
+    """
+    if pd is None:  # pragma: no cover
+        raise ImportError("pandas is required for forecasting")
+
+    if prophet_cls is None:
+        try:  # pragma: no cover - heavy dependency
+            from prophet import Prophet as prophet_cls  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise ImportError("prophet is required for forecasting") from e
+
+    hist = df_demand_history.rename(columns={"daily_sales": "y"})[["ds", "y"]]
+    model = prophet_cls()
+    model.fit(hist)
+    future = model.make_future_dataframe(periods=forecast_days)
+    forecast = model.predict(future)[["ds", "yhat"]]
+    future_sales = forecast[forecast["ds"] > hist["ds"].max()].copy()
+    future_sales["cumulative_sales"] = future_sales["yhat"].cumsum()
+    future_sales["projected_inventory"] = current_inventory - future_sales["cumulative_sales"]
+    below = future_sales[future_sales["projected_inventory"] < reorder_threshold]
+    reorder_date = below["ds"].iloc[0].date() if not below.empty else None
+    return ForecastResult(future_sales, reorder_date)
+
+
+@click.command()
+@click.argument("csv_path", type=click.Path(exists=True))
+@click.argument("current_inventory", type=int)
+@click.argument("reorder_threshold", type=int)
+@click.option("--forecast-days", default=180, show_default=True, type=int)
+def main(csv_path: str, current_inventory: int, reorder_threshold: int, forecast_days: int) -> None:
+    """CLI entry point for inventory forecasting.
+
+    CSV_PATH should contain columns ``ds`` (date) and ``daily_sales``.
+    """
+    if pd is None:  # pragma: no cover
+        raise ImportError("pandas is required for CLI usage")
+    df = pd.read_csv(csv_path, parse_dates=["ds"])
+    result = forecast_inventory(df, current_inventory, forecast_days, reorder_threshold)
+    if result.reorder_date:
+        click.echo(
+            f"Inventory will fall below {reorder_threshold} on {result.reorder_date:%Y-%m-%d}"
+        )
+    else:
+        click.echo("Inventory stays above threshold in the forecast horizon")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_stockforecast.py
+++ b/tests/test_stockforecast.py
@@ -1,0 +1,63 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from stockforecast import (
+    ForecastResult,
+    forecast_inventory,
+    generate_daily_demand,
+    simulate_stock_from_demand,
+)
+
+
+def test_import():
+    assert callable(generate_daily_demand)
+    assert callable(simulate_stock_from_demand)
+    assert callable(forecast_inventory)
+
+
+def test_simulation():
+    df = generate_daily_demand("2024-01-01", "2024-01-10", 10, "A")
+    result = simulate_stock_from_demand(df, 60, 4, 14, 7)
+    assert "stock" in result.columns
+    assert len(result) == len(df)
+
+
+def test_forecast_with_stub():
+    df = pd.DataFrame(
+        {
+            "ds": pd.date_range("2024-01-01", periods=5, freq="D"),
+            "daily_sales": [1, 1, 1, 1, 1],
+        }
+    )
+
+    class DummyProphet:
+        def fit(self, df: pd.DataFrame) -> None:
+            self.last_date = df["ds"].max()
+
+        def make_future_dataframe(self, periods: int) -> pd.DataFrame:
+            return pd.DataFrame(
+                {
+                    "ds": pd.date_range(
+                        self.last_date + pd.Timedelta(days=1), periods=periods, freq="D"
+                    )
+                }
+            )
+
+        def predict(self, future: pd.DataFrame) -> pd.DataFrame:
+            return pd.DataFrame({"ds": future["ds"], "yhat": [1.0] * len(future)})
+
+    result = forecast_inventory(
+        df,
+        current_inventory=3,
+        forecast_days=5,
+        reorder_threshold=1,
+        prophet_cls=DummyProphet,
+    )
+    assert isinstance(result, ForecastResult)
+    assert result.reorder_date is not None
+
+
+def test_missing_column():
+    with pytest.raises(ValueError):
+        simulate_stock_from_demand(pd.DataFrame({"ds": []}), 60, 4, 14, 7)


### PR DESCRIPTION
## Summary
- convert warehouse stock estimator notebook into `stockforecast` module
- document module usage in README and warehouse stock estimator docs
- add runtime and development requirements list

## New Public Functions
- `stockforecast.generate_daily_demand`
- `stockforecast.simulate_stock_from_demand`
- `stockforecast.forecast_inventory`

## Breaking Changes
- None


------
https://chatgpt.com/codex/tasks/task_e_68a29e4234c483238b8cf08f5fb09d4b