### PR TITLE
feat: extract prophet notebook to module + docs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,9 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install -r requirements.txt
-      - run: pip install pytest
-      - run: pytest -q
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+      - name: Format & Test
+        run: |
+          black --check .
+          pytest -q

--- a/README.md
+++ b/README.md
@@ -7,10 +7,19 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 | Project | 📓 Notebook | What it shows |
 |---------|-------------|---------------|
 | Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> · [Docs](docs/lidl_receipt_analysis.md) | Parses Lidl receipts and summarizes monthly spend · module `lidltracker` |
-| Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> · [Docs](docs/warehouse_stock_estimator.md) | Forecasts warehouse stock levels with the Prophet library |
+| Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> · [Docs](docs/warehouse_stock_estimator.md) | Forecasts warehouse stock levels with the Prophet library · module `warehousestock` |
 | PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> | Converts PDF catalogue tables to Excel using OCR |
 | Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
 | General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> · [Docs](docs/gpt4all_product_demo.md) | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
+### Warehouse stock estimator example
+
+```python
+from warehousestock.estimator import generate_daily_demand, forecast_reorder_date
+
+demand = generate_daily_demand("2024-01-01", "2024-01-30", 20, "ITEM_1")
+forecast = forecast_reorder_date(demand, current_stock=500, reorder_threshold=100)
+```
+
 
 
 
@@ -30,7 +39,7 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 | Projekti | 📓 Notebook | Kuvaus |
 |----------|-------------|--------|
 | Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> · [Docs](docs/lidl_receipt_analysis.md) | Analysoi kuittidataa ja tuottaa kuukausikoosteet · moduuli `lidltracker` |
-| Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> · [Docs](docs/warehouse_stock_estimator.md) | Ennustaa varastotarpeet Prophet‑kirjastolla |
+| Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> · [Docs](docs/warehouse_stock_estimator.md) | Ennustaa varastotarpeet Prophet‑kirjastolla · moduuli `warehousestock` |
 | PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
 | Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |
 | Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> · [Docs](docs/gpt4all_product_demo.md) | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|

--- a/docs/warehouse_stock_estimator.md
+++ b/docs/warehouse_stock_estimator.md
@@ -1,26 +1,24 @@
 # Warehouse Stock Estimator
 
+Utilities for simulating demand and forecasting when to reorder stock using [Prophet](https://facebook.github.io/prophet/).
+
 ## Installation
-Create a Python environment and install the required libraries:
 
 ```bash
-pip install pandas numpy prophet plotly openpyxl kaleido
+pip install -r requirements.txt
 ```
 
-## Data Preparation
-1. Mount Google Drive (if using Colab) or set a local data directory.
-2. Generate or load historical daily demand for each item. Data should contain:
-   - `item_id`: unique identifier
-   - `ds`: date column
-   - `daily_sales`: units sold per day
-3. Use the helper function to simulate stock levels from demand and export the results to Excel for verification.
+## Quick start
 
-## Running Forecasts
-1. Train a Prophet model on the historical `daily_sales` data.
-2. Create a future dataframe and forecast the next 180 days of demand.
-3. Accumulate predicted sales to project remaining inventory for each item.
-4. Save a dashboard (`forecast_dashboard.xlsx`) and individual item plots to the data directory.
+```python
+from warehousestock.estimator import generate_daily_demand, forecast_reorder_date
 
-## Interpreting Plots
-The notebook plots projected inventory levels with a horizontal reorder threshold.  
-When the inventory line crosses this threshold, schedule replenishment before the indicated date.
+demand = generate_daily_demand("2024-01-01", "2024-01-30", base_sales_mean=20, item_id="ITEM_1")
+reorder_date = forecast_reorder_date(demand, current_stock=500, reorder_threshold=100)
+print(reorder_date)
+```
+
+## Functions
+- `generate_daily_demand` – create a demand DataFrame with seasonality and noise.
+- `simulate_stock_from_demand` – simulate stock levels and replenishments.
+- `forecast_reorder_date` – predict when inventory will fall below a threshold.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+# Core runtime
+pandas>=2.2
+numpy>=1.26
+matplotlib>=3.8
+python-dateutil>=2.9
+click>=8.1
+prophet>=1.1
+
+# Dev / tests / formatting
+pytest>=8.2
+black>=24.8
+ruff>=0.5.5
+
+# Optional OCR (only if code uses OCR)
+pytesseract>=0.3.10
+Pillow>=10.3
+opencv-python-headless>=4.10

--- a/src/warehousestock/__init__.py
+++ b/src/warehousestock/__init__.py
@@ -1,0 +1,13 @@
+"""Utilities for forecasting warehouse stock levels."""
+
+from .estimator import (
+    forecast_reorder_date,
+    generate_daily_demand,
+    simulate_stock_from_demand,
+)
+
+__all__ = [
+    "generate_daily_demand",
+    "simulate_stock_from_demand",
+    "forecast_reorder_date",
+]

--- a/src/warehousestock/estimator.py
+++ b/src/warehousestock/estimator.py
@@ -1,0 +1,114 @@
+"""Forecast inventory levels and reorder dates using Prophet."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    from prophet import Prophet
+except Exception:  # pragma: no cover
+    Prophet = None  # type: ignore[assignment]
+
+
+def generate_daily_demand(
+    start_date: str | pd.Timestamp,
+    end_date: str | pd.Timestamp,
+    base_sales_mean: float,
+    item_id: str,
+) -> pd.DataFrame:
+    """Simulate daily demand for a single item.
+
+    Args:
+        start_date: First date of the simulation.
+        end_date: Last date of the simulation.
+        base_sales_mean: Average daily sales for the item.
+        item_id: Identifier for the item.
+
+    Returns:
+        DataFrame with columns ``item_id``, ``ds`` and ``daily_sales``.
+    """
+    dates = pd.date_range(start=start_date, end=end_date, freq="D")
+    df = pd.DataFrame({"ds": dates})
+    noise = np.random.normal(0, base_sales_mean * 0.1, len(df))
+    df["daily_sales"] = base_sales_mean + noise
+    df["daily_sales"] += np.sin(df["ds"].dt.dayofyear / 365 * 2 * np.pi) * (base_sales_mean * 0.2)
+    df["daily_sales"] += np.sin(df["ds"].dt.dayofweek / 7 * 2 * np.pi) * (base_sales_mean * 0.1)
+    df["daily_sales"] = df["daily_sales"].apply(lambda x: max(1, round(x)))
+    df["item_id"] = item_id
+    return df[["item_id", "ds", "daily_sales"]]
+
+
+def simulate_stock_from_demand(
+    df_demand_history: pd.DataFrame,
+    initial_stock_multiplier: int,
+    replenishment_order_size_weeks: int,
+    lead_time_days: int,
+    safety_stock_days: int,
+) -> pd.DataFrame:
+    """Simulate stock levels for historical demand data.
+
+    Args:
+        df_demand_history: Demand history with columns ``ds`` and ``daily_sales``.
+        initial_stock_multiplier: Days of average sales kept as initial stock.
+        replenishment_order_size_weeks: Order size expressed in weeks of demand.
+        lead_time_days: Supplier lead time in days.
+        safety_stock_days: Safety stock expressed in days of demand.
+
+    Returns:
+        DataFrame with an added ``stock`` column representing inventory levels.
+    """
+    df = df_demand_history.sort_values("ds").copy()
+    avg_daily_sales = df["daily_sales"].mean()
+    initial_stock = int(avg_daily_sales * initial_stock_multiplier)
+    current_stock = initial_stock
+
+    replenishment_threshold = int(avg_daily_sales * (lead_time_days + safety_stock_days))
+    replenishment_amount = int(avg_daily_sales * (replenishment_order_size_weeks * 7))
+    df["stock"] = 0
+
+    for i, row in df.iterrows():
+        df.at[i, "stock"] = current_stock
+        current_stock -= row["daily_sales"]
+        if current_stock < replenishment_threshold and i < len(df) - lead_time_days:
+            current_stock += replenishment_amount
+    return df
+
+
+def forecast_reorder_date(
+    item_data: pd.DataFrame,
+    current_stock: int,
+    reorder_threshold: int,
+    periods: int = 180,
+) -> Optional[pd.Timestamp]:
+    """Forecast when inventory will fall below a threshold.
+
+    Args:
+        item_data: DataFrame with columns ``ds`` and ``daily_sales``.
+        current_stock: Current inventory level.
+        reorder_threshold: Stock level triggering a reorder.
+        periods: Days to forecast into the future.
+
+    Returns:
+        Date when projected stock drops below ``reorder_threshold``.
+        Returns ``None`` if the threshold is not crossed within ``periods`` days.
+    """
+    if Prophet is None:  # pragma: no cover - executed only when Prophet missing
+        raise ImportError(
+            "prophet is required for forecasting. Install it via 'pip install prophet'."
+        )
+
+    prophet_df = item_data[["ds", "daily_sales"]].rename(columns={"daily_sales": "y"})
+    model = Prophet()
+    model.fit(prophet_df)
+    future = model.make_future_dataframe(periods=periods)
+    forecast = model.predict(future)
+    forecast = forecast[forecast["ds"] > prophet_df["ds"].max()].copy()
+    forecast["cumulative_sales"] = forecast["yhat"].cumsum()
+    forecast["projected_stock"] = current_stock - forecast["cumulative_sales"]
+    below = forecast[forecast["projected_stock"] <= reorder_threshold]
+    if below.empty:
+        return None
+    return pd.to_datetime(below.iloc[0]["ds"])

--- a/tests/test_warehousestock.py
+++ b/tests/test_warehousestock.py
@@ -1,0 +1,21 @@
+import warehousestock
+from warehousestock.estimator import (
+    forecast_reorder_date,
+    generate_daily_demand,
+)
+
+
+def test_import():
+    assert hasattr(warehousestock, "forecast_reorder_date")
+
+
+def test_forecast_reorder_date():
+    demand = generate_daily_demand("2024-01-01", "2024-01-10", base_sales_mean=10, item_id="SKU1")
+    date = forecast_reorder_date(demand, current_stock=50, reorder_threshold=5, periods=30)
+    assert date is not None
+
+
+def test_no_reorder_needed():
+    demand = generate_daily_demand("2024-01-01", "2024-01-10", base_sales_mean=1, item_id="SKU1")
+    date = forecast_reorder_date(demand, current_stock=1000, reorder_threshold=10, periods=30)
+    assert date is None


### PR DESCRIPTION
## Summary
- extract warehouse stock estimator logic into `warehousestock` package
- document `warehousestock` usage and add README example
- add dependency list and CI formatting/test workflow

## New Public Functions
- `generate_daily_demand`
- `simulate_stock_from_demand`
- `forecast_reorder_date`

## Breaking Changes
- none

------
https://chatgpt.com/codex/tasks/task_e_68a29f83fbdc832383baff8bf0ad8e66