### PR TITLE
feat: extract pdf_to_excel_converter to module + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,19 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 |---------|-------------|---------------|
 | Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> · [Docs](docs/lidl_receipt_analysis.md) | Parses Lidl receipts and summarizes monthly spend · module `lidltracker` |
 | Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> · [Docs](docs/warehouse_stock_estimator.md) | Forecasts warehouse stock levels with the Prophet library · module `stockforecast` |
-| PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> | Converts PDF catalogue tables to Excel using OCR |
+| PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> · [Docs](docs/pdf_to_excel_converter.md) | Converts PDF catalogue tables to Excel using OCR · module `pdf2excel` |
 | Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
 | General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> · [Docs](docs/gpt4all_product_demo.md) | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
+
+### PDF‑to‑Excel table extractor example
+
+```python
+from pdf2excel import parse_ocr_text_to_df
+
+sample = "TP123 Sample part | 100 kg 80 kg"
+df = parse_ocr_text_to_df(sample)
+```
+
 
 
 
@@ -31,7 +41,7 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 |----------|-------------|--------|
 | Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> · [Docs](docs/lidl_receipt_analysis.md) | Analysoi kuittidataa ja tuottaa kuukausikoosteet · moduuli `lidltracker` |
 | Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> · [Docs](docs/warehouse_stock_estimator.md) | Ennustaa varastotarpeet Prophet‑kirjastolla · moduuli `stockforecast` |
-| PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla |
+| PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> · [Docs](docs/pdf_to_excel_converter.md) | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla · moduuli `pdf2excel` |
 | Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |
 | Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> · [Docs](docs/gpt4all_product_demo.md) | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|
 

--- a/docs/pdf_to_excel_converter.md
+++ b/docs/pdf_to_excel_converter.md
@@ -1,0 +1,18 @@
+# PDF to Excel Converter
+
+## Objective
+Convert tabular regions in PDFs into structured Excel worksheets using OCR.
+
+## Main Functions
+- `parse_ocr_text_to_df(text: str) -> pd.DataFrame`: parse OCR output into a table.
+- `extract_pdf_table(pdf_path, page_num, crop_box, dpi=300, ocr_lang="eng") -> pd.DataFrame`: rasterize a PDF region and run OCR.
+- `save_table_to_excel(df, out_path, sheet_name="Sheet1")`: save the parsed table to an Excel file.
+
+## Example
+```python
+from pdf2excel import extract_pdf_table, save_table_to_excel
+
+bbox = (70.7, 109.7, 545.3, 215.16)
+df = extract_pdf_table("catalog.pdf", page_num=1, crop_box=bbox)
+save_table_to_excel(df, "output.xlsx", sheet_name="Jockey Wheels")
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ prophet>=1.1
 pytesseract>=0.3.10
 Pillow>=9.0
 opencv-python-headless>=4.8
+pymupdf>=1.24
 
 # Development
 pytest>=7.4

--- a/src/pdf2excel/__init__.py
+++ b/src/pdf2excel/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for converting tabular PDF regions to Excel."""
+
+from .converter import extract_pdf_table, parse_ocr_text_to_df, save_table_to_excel
+
+__all__ = ["extract_pdf_table", "parse_ocr_text_to_df", "save_table_to_excel"]

--- a/src/pdf2excel/converter.py
+++ b/src/pdf2excel/converter.py
@@ -1,0 +1,129 @@
+"""Extract tabular data from a PDF page using OCR."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+import re
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover
+    pd = None  # type: ignore
+
+ROW_RE = re.compile(
+    r"""^(?P<raw>[-FT]?P[A-Z0-9]{3,})\s+
+        (?P<desc>.*?)\s+
+        \|?\s*(?P<stat>\d+\s*kg)\s+
+        (?P<dyn>\d+\s*kg)\s*$""",
+    re.I | re.X | re.M,
+)
+
+OCR_MAP = str.maketrans(
+    {
+        "O": "0",
+        "o": "0",
+        "S": "5",
+        "s": "5",
+        "I": "1",
+        "l": "1",
+        "B": "8",
+        "-": "T",
+        "F": "T",
+        "f": "T",
+    }
+)
+
+
+def parse_ocr_text_to_df(text: str) -> "pd.DataFrame":
+    """Parse OCR'd table text into a DataFrame.
+
+    Args:
+        text: Raw text produced by OCR.
+
+    Returns:
+        DataFrame with columns ``Part nr.``, ``Description``, ``Max static load``,
+        and ``Max dynamic load``. Empty if no rows were parsed.
+    """
+
+    if pd is None:  # pragma: no cover - import guard
+        raise ImportError("pandas is required for parse_ocr_text_to_df")
+
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    lines = [ln for ln in lines if not re.search(r"\bPart\s+nr", ln, re.I)]
+    cleaned = "\n".join(lines)
+
+    rows = []
+    for match in ROW_RE.finditer(cleaned):
+        part_norm = match.group("raw").translate(OCR_MAP)
+        if re.fullmatch(r"TP\d{3,}", part_norm):
+            rows.append(
+                {
+                    "Part nr.": part_norm,
+                    "Description": match.group("desc").strip(),
+                    "Max static load": match.group("stat"),
+                    "Max dynamic load": match.group("dyn"),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def extract_pdf_table(
+    pdf_path: str | Path,
+    page_num: int,
+    crop_box: Tuple[float, float, float, float],
+    dpi: int = 300,
+    ocr_lang: str = "eng",
+) -> "pd.DataFrame":
+    """Extract a table region from a PDF via OCR.
+
+    This function requires ``pymupdf``, ``pytesseract``, and ``Pillow``. These are
+    optional and are only imported when the function is called.
+
+    Args:
+        pdf_path: Path to the PDF file.
+        page_num: 1-based page number to process.
+        crop_box: Bounding box ``(x0, y0, x1, y1)`` specifying the table region.
+        dpi: Rasterization resolution for OCR.
+        ocr_lang: Tesseract language code.
+
+    Returns:
+        DataFrame parsed from the OCR text.
+    """
+
+    if pd is None:  # pragma: no cover
+        raise ImportError("pandas is required for extract_pdf_table")
+
+    try:  # pragma: no cover - optional dependency
+        import fitz  # type: ignore
+        from PIL import Image  # type: ignore
+        import pytesseract  # type: ignore
+        import io
+    except Exception as exc:  # pragma: no cover
+        raise ImportError(
+            "pymupdf, pillow, and pytesseract must be installed to extract tables"
+        ) from exc
+
+    page = fitz.open(pdf_path).load_page(page_num - 1)
+    pix = page.get_pixmap(matrix=fitz.Matrix(dpi / 72, dpi / 72), clip=fitz.Rect(*crop_box))
+    img = Image.open(io.BytesIO(pix.tobytes()))
+    ocr_text = pytesseract.image_to_string(img, lang=ocr_lang)
+    return parse_ocr_text_to_df(ocr_text)
+
+
+def save_table_to_excel(
+    df: "pd.DataFrame",
+    out_path: str | Path,
+    sheet_name: str = "Sheet1",
+) -> None:
+    """Save a DataFrame to an Excel file.
+
+    Args:
+        df: DataFrame returned from :func:`extract_pdf_table` or
+            :func:`parse_ocr_text_to_df`.
+        out_path: Destination ``.xlsx`` file.
+        sheet_name: Name of the sheet to create.
+    """
+
+    df.to_excel(out_path, sheet_name=sheet_name, index=False)

--- a/src/stockforecast/__init__.py
+++ b/src/stockforecast/__init__.py
@@ -1,6 +1,7 @@
 """Utilities for forecasting warehouse stock levels."""
 
 from .forecast import (
+    ForecastResult,
     generate_daily_demand,
     simulate_stock_from_demand,
     forecast_inventory,
@@ -8,6 +9,7 @@ from .forecast import (
 )
 
 __all__ = [
+    "ForecastResult",
     "generate_daily_demand",
     "simulate_stock_from_demand",
     "forecast_inventory",

--- a/tests/test_pdf2excel.py
+++ b/tests/test_pdf2excel.py
@@ -1,0 +1,18 @@
+def test_import():
+    import pdf2excel  # noqa: F401
+
+
+def test_parse_rows():
+    from pdf2excel import parse_ocr_text_to_df
+
+    text = "TP123 Sample part | 100 kg 80 kg"
+    df = parse_ocr_text_to_df(text)
+    assert not df.empty
+    assert df.loc[0, "Part nr."] == "TP123"
+
+
+def test_parse_empty():
+    from pdf2excel import parse_ocr_text_to_df
+
+    df = parse_ocr_text_to_df("")
+    assert df.empty

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -22,8 +22,8 @@ def test_process_folder(tmp_path: Path):
     receipt.write_text(sample, encoding="utf-8")
 
     data = process_receipts_folder(tmp_path, tmp_path / "out.csv")
-    assert any(row["item"] == "Milk" for row in data)
-    milk = next(row for row in data if row["item"] == "Milk")
+    assert (data["item"] == "Milk").any()
+    milk = data[data["item"] == "Milk"].iloc[0]
     assert milk["category"] == "Dairy"
     assert (tmp_path / "out.csv").exists()
 


### PR DESCRIPTION
## Summary
- convert PDF-to-Excel table extractor notebook into `pdf2excel` module
- document PDF table extraction and provide README example
- add smoke tests and export `ForecastResult`

## Testing
- `PYTHONPATH=src pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2a113433c8323934bc6aa977bd212