### PR TITLE
feat: extract Product_Description_Keyword_Extraction_Demo to module + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Mäntsälä, Finland | Open to remote / hybrid roles in data, ERP, logistics or 
 | Lidl receipt analysis tool | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">View</a> · [Docs](docs/lidl_receipt_analysis.md) | Parses Lidl receipts and summarizes monthly spend · module `lidltracker` |
 | Warehouse stock estimator | <a href="Toolbox/notebooks/prophet.ipynb">View</a> · [Docs](docs/warehouse_stock_estimator.md) | Forecasts warehouse stock levels with the Prophet library · module `stockforecast` |
 | PDF‑to‑Excel table extractor | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">View</a> · [Docs](docs/pdf_to_excel_converter.md) | Converts PDF catalogue tables to Excel using OCR · module `pdf2excel` |
-| Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> | Extracts technical keywords from messy product descriptions for MDM preprocessing |
+| Product description keyword extractor | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">View</a> · [Docs](docs/product_keyword_extractor.md) | Extracts technical keywords from messy product descriptions for MDM preprocessing · module `productkeywords` |
 | General GPT4ALL demo with product data | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">View</a> · [Docs](docs/gpt4all_product_demo.md) | PDF page → product lines; GPT 4ALL detects changes & normalizes fields|
 
 ### PDF‑to‑Excel table extractor example
@@ -19,6 +19,25 @@ from pdf2excel import parse_ocr_text_to_df
 
 sample = "TP123 Sample part | 100 kg 80 kg"
 df = parse_ocr_text_to_df(sample)
+```
+
+### Product description keyword extractor example
+
+```python
+from productkeywords import extract_keywords_df
+import pandas as pd
+
+categories = {"m": ["M6"], "Din": ["931"]}
+
+df = pd.DataFrame(
+    {
+        "ItemID": [1],
+        "ItemDescrEng1": ["M6 Bolt"],
+        "ItemDescrEng2": ["DIN931 10.9"],
+    }
+)
+
+extract_keywords_df(df, categories)
 ```
 
 
@@ -40,6 +59,6 @@ Data‑analyytikko ja automaation rakentaja | Python, ERP‑integraatiot & data�
 | Lidlin kuittidatan analysointityökalu | <a href="Toolbox/notebooks/Lidl_receipt_financial_tracker.ipynb">Näytä</a> · [Docs](docs/lidl_receipt_analysis.md) | Analysoi kuittidataa ja tuottaa kuukausikoosteet · moduuli `lidltracker` |
 | Varastosaldon ennustaja | <a href="Toolbox/notebooks/prophet.ipynb">Näytä</a> · [Docs](docs/warehouse_stock_estimator.md) | Ennustaa varastotarpeet Prophet‑kirjastolla · moduuli `stockforecast` |
 | PDF → Excel muunnin | <a href="Toolbox/notebooks/pdf_to_excel_converter.ipynb">Näytä</a> · [Docs](docs/pdf_to_excel_converter.md) | Muuntaa PDF‑taulukot Excel‑muotoon OCR:lla · moduuli `pdf2excel` |
-| Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> | Poimii tekniset avainsanat sekavasta tuotedatasta |
+| Tuotekuvausten harmonisointi | <a href="Toolbox/notebooks/Product_Description_Keyword_Extraction_Demo.ipynb">Näytä</a> · [Docs](docs/product_keyword_extractor.md) | Poimii tekniset avainsanat sekavasta tuotedatasta · moduuli `productkeywords` |
 | Yleisdemo GPT4ALL käytöstä tuotedatan hallinnassa | <a href="Toolbox/notebooks/SKU_Demo_ZERO_SETUP.ipynb">Näytä</a> · [Docs](docs/gpt4all_product_demo.md) | PDF sivu muutetaan riveiksi tuotteita; GPT4ALL havaitsee erot ja normalisoi kentät|
 

--- a/docs/product_keyword_extractor.md
+++ b/docs/product_keyword_extractor.md
@@ -1,0 +1,22 @@
+# Product description keyword extractor
+
+Utilities for pulling structured keywords from messy product descriptions.
+
+## Example
+
+```python
+from productkeywords import extract_keywords_df
+import pandas as pd
+
+categories = {"m": ["M6"], "Din": ["931"]}
+
+df = pd.DataFrame(
+    {
+        "ItemID": [1],
+        "ItemDescrEng1": ["M6 Bolt"],
+        "ItemDescrEng2": ["DIN931 10.9"],
+    }
+)
+
+result = extract_keywords_df(df, categories)
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,22 +15,3 @@ ruff>=0.5.5
 pytesseract>=0.3.10
 Pillow>=10.3
 opencv-python-headless>=4.10
-=======
-# Runtime
-pandas>=1.5
-numpy>=1.24
-matplotlib>=3.7
-python-dateutil>=2.8
-click>=8.1
-prophet>=1.1
-
-# Optional OCR
-pytesseract>=0.3.10
-Pillow>=9.0
-opencv-python-headless>=4.8
-pymupdf>=1.24
-
-# Development
-pytest>=7.4
-black>=23.7
-ruff>=0.1

--- a/src/productkeywords/__init__.py
+++ b/src/productkeywords/__init__.py
@@ -1,0 +1,5 @@
+"""Keyword extraction from product descriptions."""
+
+from .extractor import extract_keywords_df, process_description
+
+__all__ = ["extract_keywords_df", "process_description"]

--- a/src/productkeywords/extractor.py
+++ b/src/productkeywords/extractor.py
@@ -1,0 +1,68 @@
+"""Utilities for extracting keywords from product descriptions."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover
+    pd = None  # type: ignore
+
+
+def process_description(
+    description: str | None, categories: Dict[str, List[str]]
+) -> Dict[str, str]:
+    """Extract first matching term for each category from a description.
+
+    Args:
+        description: Free-form product description.
+        categories: Mapping of category names to lists of candidate terms.
+
+    Returns:
+        Mapping of categories to the first matching term found in the description.
+    """
+
+    keywords: Dict[str, str] = {}
+    if not isinstance(description, str):
+        return keywords
+    for category, terms in categories.items():
+        for term in terms:
+            if re.search(rf"\b{re.escape(term)}\b", description, re.IGNORECASE):
+                keywords[category] = term
+                break
+    return keywords
+
+
+def extract_keywords_df(
+    df: "pd.DataFrame",
+    categories: Dict[str, List[str]],
+    descr1_col: str = "ItemDescrEng1",
+    descr2_col: str = "ItemDescrEng2",
+) -> "pd.DataFrame":
+    """Add combined description and keyword extraction columns to ``df``.
+
+    Args:
+        df: DataFrame containing at least ``ItemID`` and description columns.
+        categories: Mapping of category names to lists of candidate terms.
+        descr1_col: Name of the first description column.
+        descr2_col: Name of the second description column.
+
+    Returns:
+        DataFrame with ``ItemID``, ``FullDescription``, and ``Keywords`` columns.
+    """
+
+    if pd is None:  # pragma: no cover - import guard
+        raise ImportError("pandas is required for extract_keywords_df")
+
+    temp = df.copy()
+    temp["FullDescription"] = (
+        temp[descr1_col].fillna("").astype(str)
+        + " "
+        + temp[descr2_col].fillna("").astype(str)
+    ).str.strip()
+    temp["Keywords"] = temp["FullDescription"].apply(
+        lambda d: process_description(d, categories)
+    )
+    return temp[["ItemID", "FullDescription", "Keywords"]]

--- a/tests/test_productkeywords.py
+++ b/tests/test_productkeywords.py
@@ -1,0 +1,27 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from productkeywords import extract_keywords_df, process_description
+
+
+def test_import():
+    import productkeywords  # noqa: F401
+
+
+def test_extract_keywords_df_basic():
+    df = pd.DataFrame(
+        {
+            "ItemID": [1],
+            "ItemDescrEng1": ["M6 Bolt"],
+            "ItemDescrEng2": ["DIN931 10.9"],
+        }
+    )
+    categories = {"m": ["M5", "M6"], "Din": ["931"]}
+    out = extract_keywords_df(df, categories)
+    assert out.loc[0, "Keywords"]["m"] == "M6"
+    assert out.loc[0, "Keywords"]["Din"] == "931"
+
+
+def test_process_description_non_string():
+    assert process_description(None, {"m": ["M5"]}) == {}


### PR DESCRIPTION
## Summary
- add productkeywords package with helper to extract structured keywords
- document product keyword extractor and show usage in README
- add smoke tests and clean requirements list

## Testing
- `black --check src/productkeywords/extractor.py tests/test_productkeywords.py`
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a2a2fcbd9883238f4008ead4621580