### PR TITLE
Add simulated pipeline playbook notebook

### DIFF
--- a/docs/simulated_pipeline_playbook.ipynb
+++ b/docs/simulated_pipeline_playbook.ipynb
@@ -1,0 +1,462 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Simulated Data Pipeline Playbook\n",
+        "\n",
+        "This notebook demonstrates how to simulate end-to-end pipelines that move data from an on-premises environment into a data lake and onward to Snowflake.\n",
+        "We will focus on showing the **techniques** that practitioners would use, including how to reconcile schema differences before merging data into a final analytics database."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 0. Imports & Configuration\n",
+        "\n",
+        "We rely on pandas to stand in for the compute engines (Spark, Snowflake) and use Python dictionaries to emulate configuration artifacts."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "from pathlib import Path\n",
+        "\n",
+        "BASE_PATH = Path('simulated_storage')\n",
+        "BASE_PATH.mkdir(exist_ok=True)\n",
+        "print('Working directory prepared:', BASE_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Scenario Setup\n",
+        "\n",
+        "To keep a consistent business story, we will follow a fictional retail company consolidating online orders. Data originates from multiple source systems:\n",
+        "\n",
+        "* **AVS (On-Prem / VM)**: Legacy ERP extracts that use snake_case headers.\n",
+        "* **Data Lake Landing**: Semi-structured JSON exports with camelCase headers and nested attributes.\n",
+        "* **Snowflake**: Target warehouse expecting business-friendly Pascal Case headers.\n",
+        "\n",
+        "In real life we would connect to each platform with vendor-specific connectors. Here, we simulate those reads with local files while emphasizing best practices such as configuration-driven ingestion and schema validation."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 1.1 Sample Source Files\n",
+        "\n",
+        "We create three mock datasets with intentionally mismatched headers to illustrate transformation needs:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "avs_orders = pd.DataFrame({\n",
+        "    'order_id': [101, 102, 103],\n",
+        "    'customer_id': ['C001', 'C002', 'C003'],\n",
+        "    'order_total': [250.0, 190.5, 330.25],\n",
+        "    'order_ts': ['2024-03-01 10:15:00', '2024-03-01 12:30:00', '2024-03-02 09:45:00']\n",
+        "})\n",
+        "\n",
+        "raw_lake_orders = pd.DataFrame({\n",
+        "    'OrderID': ['A-900', 'A-901'],\n",
+        "    'CustomerCode': ['C002', 'C004'],\n",
+        "    'GrossAmount': [210.0, 480.0],\n",
+        "    'UpdatedAt': ['2024-03-02T14:00:00Z', '2024-03-02T16:20:00Z']\n",
+        "})\n",
+        "\n",
+        "partner_feed = pd.DataFrame({\n",
+        "    'ORDER NUMBER': [5001, 5002],\n",
+        "    'CUSTOMER': ['C001', 'C005'],\n",
+        "    'TOTAL $': [125.5, 275.75],\n",
+        "    'MODIFIED': ['2024/03/03 08:30:00', '2024/03/03 09:10:00']\n",
+        "})\n",
+        "\n",
+        "avs_orders, raw_lake_orders, partner_feed"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Ingestion Techniques\n",
+        "\n",
+        "### 2.1 Configuration-Driven Connectors\n",
+        "\n",
+        "Real pipelines rely on configuration maps to determine connection parameters and mapping logic. Below we define metadata that describes each source, its storage layer, and how headers should be normalized."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "source_config = {\n",
+        "    'avs_orders': {\n",
+        "        'layer': 'AVS',\n",
+        "        'read_format': 'csv',\n",
+        "        'primary_key': 'order_id',\n",
+        "        'expected_headers': ['order_id', 'customer_id', 'order_total', 'order_ts'],\n",
+        "        'rename_map': {\n",
+        "            'order_id': 'OrderID',\n",
+        "            'customer_id': 'CustomerID',\n",
+        "            'order_total': 'Amount',\n",
+        "            'order_ts': 'UpdatedAt'\n",
+        "        }\n",
+        "    },\n",
+        "    'raw_lake_orders': {\n",
+        "        'layer': 'DataLake',\n",
+        "        'read_format': 'json',\n",
+        "        'primary_key': 'OrderID',\n",
+        "        'expected_headers': ['OrderID', 'CustomerCode', 'GrossAmount', 'UpdatedAt'],\n",
+        "        'rename_map': {\n",
+        "            'OrderID': 'OrderID',\n",
+        "            'CustomerCode': 'CustomerID',\n",
+        "            'GrossAmount': 'Amount',\n",
+        "            'UpdatedAt': 'UpdatedAt'\n",
+        "        }\n",
+        "    },\n",
+        "    'partner_feed': {\n",
+        "        'layer': 'PartnerFTP',\n",
+        "        'read_format': 'xlsx',\n",
+        "        'primary_key': 'ORDER NUMBER',\n",
+        "        'expected_headers': ['ORDER NUMBER', 'CUSTOMER', 'TOTAL $', 'MODIFIED'],\n",
+        "        'rename_map': {\n",
+        "            'ORDER NUMBER': 'OrderID',\n",
+        "            'CUSTOMER': 'CustomerID',\n",
+        "            'TOTAL $': 'Amount',\n",
+        "            'MODIFIED': 'UpdatedAt'\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
+        "source_config"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2.2 Schema Validation Utility\n",
+        "\n",
+        "A lightweight validation function checks whether the incoming headers match expectations. In production, this step would raise alerts or move files to quarantine when mismatches occur."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def validate_headers(df: pd.DataFrame, config: dict, *, source: str) -> None:\n",
+        "    actual = list(df.columns)\n",
+        "    expected = config[source]['expected_headers']\n",
+        "    missing = set(expected) - set(actual)\n",
+        "    extra = set(actual) - set(expected)\n",
+        "    if missing or extra:\n",
+        "        print(f\"[WARN] {source}: header mismatch detected\")\n",
+        "        if missing:\n",
+        "            print('  Missing columns:', ', '.join(sorted(missing)))\n",
+        "        if extra:\n",
+        "            print('  Unexpected columns:', ', '.join(sorted(extra)))\n",
+        "    else:\n",
+        "        print(f\"[OK] {source}: headers aligned\")\n",
+        "\n",
+        "validate_headers(avs_orders, source_config, source='avs_orders')\n",
+        "validate_headers(raw_lake_orders, source_config, source='raw_lake_orders')\n",
+        "validate_headers(partner_feed, source_config, source='partner_feed')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Data Lake Landing (Bronze/Silver)\n",
+        "\n",
+        "We mimic a bronze-to-silver process. Bronze keeps the data as-is but tracks metadata. Silver standardizes header names, harmonizes datatypes, and enriches records with a unified surrogate key."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def normalize_headers(df: pd.DataFrame, rename_map: dict) -> pd.DataFrame:\n",
+        "    return df.rename(columns=rename_map)\n",
+        "\n",
+        "bronze_tables = {\n",
+        "    'avs_orders_bronze': avs_orders.copy(),\n",
+        "    'raw_lake_orders_bronze': raw_lake_orders.copy(),\n",
+        "    'partner_feed_bronze': partner_feed.copy()\n",
+        "}\n",
+        "\n",
+        "silver_tables = {}\n",
+        "for source, bronze_df in bronze_tables.items():\n",
+        "    cfg_key = source.replace('_bronze', '')\n",
+        "    renamed = normalize_headers(bronze_df, source_config[cfg_key]['rename_map'])\n",
+        "    renamed['IngestedFrom'] = source_config[cfg_key]['layer']\n",
+        "    silver_tables[source.replace('_bronze', '_silver')] = renamed\n",
+        "\n",
+        "silver_tables"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 3.1 Type Harmonization\n",
+        "\n",
+        "Notice that timestamps and numeric fields follow different patterns. We centralize casting rules to avoid repeated transformation logic."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "dtype_rules = {\n",
+        "    'OrderID': 'string',\n",
+        "    'CustomerID': 'string',\n",
+        "    'Amount': 'float',\n",
+        "    'UpdatedAt': 'datetime64[ns]'\n",
+        "}\n",
+        "\n",
+        "for table_name, df in silver_tables.items():\n",
+        "    typed_df = df.astype({k: v for k, v in dtype_rules.items() if k in df.columns}, errors='ignore')\n",
+        "    typed_df['UpdatedAt'] = pd.to_datetime(typed_df['UpdatedAt'], errors='coerce')\n",
+        "    silver_tables[table_name] = typed_df\n",
+        "\n",
+        "silver_tables['avs_orders_silver'].dtypes"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Snowflake Loading & Transformation\n",
+        "\n",
+        "In production we would use Snowflake stages and `COPY INTO` commands. Here, we consolidate the silver tables into a single **gold** table while applying business rules:\n",
+        "\n",
+        "* Deduplicate on `OrderID` preferring the most recent `UpdatedAt`.\n",
+        "* Create human-readable headers expected by analytics teams.\n",
+        "* Split the output into two presentation formats: a wide executive report and a transactional view."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "combined = pd.concat(silver_tables.values(), ignore_index=True)\n",
+        "combined = combined.sort_values('UpdatedAt').drop_duplicates('OrderID', keep='last')\n",
+        "combined['Amount'] = combined['Amount'].round(2)\n",
+        "combined['UpdatedAt'] = combined['UpdatedAt'].dt.tz_localize('UTC')\n",
+        "combined"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 4.1 Final Warehouse Schema\n",
+        "\n",
+        "Snowflake tables often use Pascal Case. We also demonstrate how to produce variant header layouts."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "warehouse_view = combined.rename(columns={\n",
+        "    'OrderID': 'OrderId',\n",
+        "    'CustomerID': 'CustomerId',\n",
+        "    'Amount': 'NetAmount',\n",
+        "    'UpdatedAt': 'UpdatedAtUtc',\n",
+        "    'IngestedFrom': 'SourceSystem'\n",
+        "})\n",
+        "warehouse_view"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 4.2 Executive Summary Layout\n",
+        "\n",
+        "Business stakeholders sometimes request multi-level headers that distinguish metrics from metadata. Pandas styling allows us to mimic the resulting presentation layer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "executive_summary = warehouse_view.copy()\n",
+        "executive_summary.columns = pd.MultiIndex.from_tuples([\n",
+        "    ('Identity', 'OrderId'),\n",
+        "    ('Identity', 'CustomerId'),\n",
+        "    ('Financials', 'NetAmount'),\n",
+        "    ('Operational', 'UpdatedAtUtc'),\n",
+        "    ('Operational', 'SourceSystem')\n",
+        "])\n",
+        "executive_summary"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Orchestration & Monitoring Patterns\n",
+        "\n",
+        "Below is a pseudo-code Airflow DAG highlighting how these transformations would be orchestrated in a production setting."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from textwrap import dedent\n",
+        "\n",
+        "airflow_dag = dedent('''\n",
+        "from airflow import DAG\n",
+        "from airflow.operators.python import PythonOperator\n",
+        "from datetime import datetime\n",
+        "\n",
+        "with DAG(\n",
+        "    dag_id=\"retail_orders_pipeline\",\n",
+        "    start_date=datetime(2024, 3, 1),\n",
+        "    schedule_interval=\"0 * * * *\",\n",
+        "    catchup=False,\n",
+        ") as dag:\n",
+        "\n",
+        "    extract_avs = PythonOperator(\n",
+        "        task_id=\"extract_avs\",\n",
+        "        python_callable=extract_from_avs,\n",
+        "    )\n",
+        "\n",
+        "    load_bronze = PythonOperator(\n",
+        "        task_id=\"load_bronze\",\n",
+        "        python_callable=write_to_bronze,\n",
+        "    )\n",
+        "\n",
+        "    transform_silver = PythonOperator(\n",
+        "        task_id=\"transform_silver\",\n",
+        "        python_callable=standardize_headers,\n",
+        "    )\n",
+        "\n",
+        "    publish_gold = PythonOperator(\n",
+        "        task_id=\"publish_gold\",\n",
+        "        python_callable=publish_to_snowflake,\n",
+        "    )\n",
+        "\n",
+        "    extract_avs >> load_bronze >> transform_silver >> publish_gold\n",
+        "''')\n",
+        "print(airflow_dag)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. End-to-End Demonstration\n",
+        "\n",
+        "Finally, we package the transformations into reusable functions to demonstrate how a single orchestration call could drive the pipeline.\n",
+        "\n",
+        "> **Tip:** In a real deployment, each function would live in its own module with logging, error handling, retry logic, and parameterization for environment-specific values."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def standardize_source(df: pd.DataFrame, cfg_key: str) -> pd.DataFrame:\n",
+        "    cfg = source_config[cfg_key]\n",
+        "    validate_headers(df, source_config, source=cfg_key)\n",
+        "    normalized = normalize_headers(df, cfg['rename_map'])\n",
+        "    normalized['IngestedFrom'] = cfg['layer']\n",
+        "    return normalized.astype({\n",
+        "        'OrderID': 'string',\n",
+        "        'CustomerID': 'string',\n",
+        "        'Amount': 'float'\n",
+        "    }, errors='ignore')\n",
+        "\n",
+        "def run_pipeline(sources: dict[str, pd.DataFrame]) -> tuple[pd.DataFrame, pd.DataFrame]:\n",
+        "    silver = [standardize_source(df, key) for key, df in sources.items()]\n",
+        "    combined_df = pd.concat(silver, ignore_index=True)\n",
+        "    combined_df['UpdatedAt'] = pd.to_datetime(combined_df['UpdatedAt'], errors='coerce')\n",
+        "    combined_df = combined_df.sort_values('UpdatedAt').drop_duplicates('OrderID', keep='last')\n",
+        "    warehouse_df = combined_df.rename(columns={\n",
+        "        'OrderID': 'OrderId',\n",
+        "        'CustomerID': 'CustomerId',\n",
+        "        'Amount': 'NetAmount',\n",
+        "        'UpdatedAt': 'UpdatedAtUtc',\n",
+        "        'IngestedFrom': 'SourceSystem'\n",
+        "    })\n",
+        "    exec_summary = warehouse_df.copy()\n",
+        "    exec_summary.columns = pd.MultiIndex.from_tuples([\n",
+        "        ('Identity', 'OrderId'),\n",
+        "        ('Identity', 'CustomerId'),\n",
+        "        ('Financials', 'NetAmount'),\n",
+        "        ('Operational', 'UpdatedAtUtc'),\n",
+        "        ('Operational', 'SourceSystem')\n",
+        "    ])\n",
+        "    return warehouse_df, exec_summary\n",
+        "\n",
+        "warehouse_df, exec_summary = run_pipeline({\n",
+        "    'avs_orders': avs_orders,\n",
+        "    'raw_lake_orders': raw_lake_orders,\n",
+        "    'partner_feed': partner_feed\n",
+        "})\n",
+        "warehouse_df, exec_summary"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Key Takeaways\n",
+        "\n",
+        "* **Schema reconciliation** is the heart of multi-source consolidation. The configuration maps give a repeatable way to translate headers, enforce types, and annotate provenance.\n",
+        "* **Layered storage (Bronze \u2192 Silver \u2192 Gold)** enables auditable transformations and simplifies debugging when data drifts.\n",
+        "* **Presentation models** can diverge dramatically from raw data structures; designing reusable formatting logic avoids one-off reporting hacks.\n",
+        "\n",
+        "This notebook can serve as a sandbox for experimenting with additional sources, validation rules, and monitoring hooks before wiring up production pipelines."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create a simulated data pipeline playbook notebook to illustrate AVS, data lake, and Snowflake scenarios
- demonstrate header normalization, type harmonization, and gold-layer presentation outputs including multi-level headers
- include pseudo-code orchestration example and reusable functions for an end-to-end mock run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9f2ce0b508323b1f314ddc9b02ac7